### PR TITLE
feat: parse newer yocto sdpx archives

### DIFF
--- a/ics_sbom_libs/cve_match/cvematcher.py
+++ b/ics_sbom_libs/cve_match/cvematcher.py
@@ -161,7 +161,15 @@ def process(spdx_document: SPDXDocument, db_path: pathlib.Path):
                     unique_cpes[cpe].extend(packages)
             package_pbar.update()
 
-    pbar = tqdm(total=len(unique_cpes), desc="Checking CPEs for Known Issues", unit="cpes", mininterval=0, miniters=1)
+    pbar = tqdm(
+        total=len(unique_cpes),
+        desc="Checking CPEs for Known Issues",
+        unit="cpes",
+        mininterval=0,
+        miniters=1,
+        position=0,
+        leave=True,
+    )
     if use_parallel:
         with ProcessPoolExecutor() as executor:
             future_result = {executor.submit(find_cves_for_cpe, cpe, db_path): cpe for cpe in unique_cpes}

--- a/ics_sbom_libs/sbom_import/parse_anything.py
+++ b/ics_sbom_libs/sbom_import/parse_anything.py
@@ -91,6 +91,7 @@ class FilterList:
             "-src",
             "-native",
             "-cross-",
+            "-source-",
         ]
 
     @property
@@ -423,8 +424,9 @@ class FilteredParser:
             ]
 
         files: list
+
         if pattern_dir:
-            files = [f for f in tf.getmembers() if f.name.startswith(pattern_dir[0]) and not f.isdir()]
+            files = [f for p in pattern_dir for f in tf.getmembers() if p in f.name and not f.isdir()]
         else:
             files = [f for f in tf.getmembers() if not f.isdir() and ".spdx" in f.name]
 


### PR DESCRIPTION
 - Support Yocto `Scarthgap` + Spdx archive format
   - parse All  `recipes` | `package`  dirs
   - Add `-sources`  to the default exclude list (New version less recipe that makes a recipe...) 
 - Stop tqdm from scrolling the screen 
