### PR TITLE
Version Handling Fix

### DIFF
--- a/ics_sbom_libs/cve_match/cvematcher.py
+++ b/ics_sbom_libs/cve_match/cvematcher.py
@@ -15,7 +15,7 @@ from .matchresult import MatchResult
 import semantic_version
 import pathlib
 
-from rich import table
+from rich import table, print
 
 from beartype.typing import Optional
 from cpeparser import CpeParser
@@ -336,14 +336,21 @@ def find_cve_with_cpe(cpe: str, db: VulnerabilityDatabase) -> CpeMatchResult:
 
     res = cursor.fetchall()
 
-    if not res:
-        return result
-    for cve in res:
-        include = cve_version_included(db, cve[0], product, version, sql_ex=second_query)
+    try:
+        if not res:
+            return result
+        for cve in res:
+            include = cve_version_included(db, cve[0], product, version, sql_ex=second_query)
 
-        if include:
-            vuln = db.get_cve(cve[0])
-            result.append_cve(vuln)
+            if include:
+                vuln = db.get_cve(cve[0])
+                result.append_cve(vuln)
+
+    except ValueError as vError:
+        print(
+            f"[red][b]ERROR:[/b] While processing {product} by {vendor} with version {version} had error:"
+            f" {vError}[/red]"
+        )
 
     return result
 

--- a/ics_sbom_libs/cve_match/package_matching/handlers/linux_kernel.py
+++ b/ics_sbom_libs/cve_match/package_matching/handlers/linux_kernel.py
@@ -18,6 +18,9 @@ class LinuxKernelVersionHandler(VersionHandler):
         if ver in invalid_version_list:
             return ver
 
+        if " " in ver:
+            ver = ver.strip()
+
         if ver.count("-") == 0:
             pkg_version = self.version_type.coerce(ver)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ics_sbom_libs"
-version = "1.2.0"
+version = "1.2.1"
 description = "ICS SBoM libs is a set of libraries developed by Integrated Computer Solutions (ICS) for handling Software Bill of Materials (SBoM) documentaion."
 ### Poetry apparently doesn't support multiline descriptions.
 #"""


### PR DESCRIPTION
Fixes #21.

Bad data was being found in the NVD database.  When converting the NVD version to a VersionType, added a str.strip() call to make sure that any spaces surrounding the version  was stripped.