### PR TITLE
reuse: add missing tags for FilterSpec.md

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,7 @@ jobs:
       - name: Check Code Quality
         run: flake8 --max-line-length 120 ics_sbom_libs/
       - name: Check Reuse Compliance
-        uses: fsfe/reuse-action@v4
-        with:
-          args: spdx
+        uses: fsfe/reuse-action@v5
 
   build:
     name: Build

--- a/ics_sbom_libs/sbom_import/FilterSpec.md
+++ b/ics_sbom_libs/sbom_import/FilterSpec.md
@@ -1,3 +1,8 @@
+<!--
+   SPDX-FileCopyrightText: 2025 ICS inc.
+   SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
 # ISCBOM Filter Spec
 
 ## Intro


### PR DESCRIPTION
 - Adds missing SPDX info to FilterSpec markdown file
 - CI: Call reuse lint to ensure reuse compliance