### PR TITLE
Support newer yocto archives

### DIFF
--- a/ics_sbom_libs/sbom_import/FilterSpec.md
+++ b/ics_sbom_libs/sbom_import/FilterSpec.md
@@ -356,6 +356,7 @@ Below, is the current filter used as default in the ICS_SBOM_LIBS.
             "-cross-",
             "-source-",
             "-headers",
+            "index.json",
   ],
 }
 ```

--- a/ics_sbom_libs/sbom_import/parse_anything.py
+++ b/ics_sbom_libs/sbom_import/parse_anything.py
@@ -93,6 +93,7 @@ class FilterList:
             "-cross-",
             "-source-",
             "-headers",
+            "index.json",
         ]
 
     @property

--- a/ics_sbom_libs/sbom_import/parse_anything.py
+++ b/ics_sbom_libs/sbom_import/parse_anything.py
@@ -9,7 +9,12 @@ import re
 import json
 
 import pathlib
-import tarfile
+import sys
+
+if sys.version_info >= (3, 14):
+    import tarfile
+else:
+    from backports.zstd import tarfile
 import argparse
 
 from cpeparser import CpeParser

--- a/ics_sbom_libs/sbom_import/parse_anything.py
+++ b/ics_sbom_libs/sbom_import/parse_anything.py
@@ -254,7 +254,10 @@ class FilteredParser:
             self.filter_list.set_filters_from_file(args.filter_file)
 
         if args.tar_dir_pattern:
-            self._tar_dir_pattern = args.tar_dir_pattern
+            if args.tar_dir_pattern == "recipes" and not args.regex_pattern:
+                args.regex_pattern = r"(\/recipe-\S+$|^recipe-\S+$)"
+            else:
+                self._tar_dir_pattern = args.tar_dir_pattern
 
         if args.regex_pattern:
             self._regex_pattern = args.regex_pattern

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ rich = "*"
 rich-argparse = "*"
 
 lib4sbom = "*"
+backports-zstd = { version = "*", markers = "python_version < '3.14'" }
 
 pyodbc = "*"
 psycopg2-binary = "*"


### PR DESCRIPTION
 - ingore `index.json`
 - Add `-r | --regex_pattern` option
 - when `-t recipes` is used silently set our regex to `(\/recipe-\S+$|^recipe-\S+$)` 
 - add support for `tar.zst`
